### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Merced County 511 — Clean Build v2</title>
+  <title>Merced County 511 — Clean Build v2 (CMS polish)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://unpkg.com/maplibre-gl@3.5.2/dist/maplibre-gl.css" rel="stylesheet" />
   <!-- Inline favicon to prevent 404s on GH Pages -->
@@ -21,6 +21,47 @@
     .k { width:10px;height:10px;border-radius:2px;display:inline-block;margin-right:.3rem;vertical-align:middle;}
     .popup-list { max-width: 320px;}
     .popup-list button { display:block; width:100%; text-align:left; margin:.25rem 0; padding:.4rem .5rem; border-radius:8px; border:1px solid color-mix(in oklab, CanvasText 30%, transparent); background:color-mix(in oklab, Canvas, CanvasText 6%/60%); cursor:pointer; }
+
+    /* =====================
+       CMS SIGN LOOK & FEEL
+       ===================== */
+    .cms-sign { 
+      --led:#f7b500; /* amber */
+      --led-glow:#facc15;
+      --face:#111;
+      background: radial-gradient(120% 120% at 50% 50%, #000 0%, #0a0a0a 40%, #111 100%);
+      color: var(--led);
+      border-radius: 12px;
+      border: 1px solid #222;
+      box-shadow: inset 0 0 0 1px #000, 0 8px 24px rgba(0,0,0,.35);
+      padding: 10px 12px;
+      max-width: 320px;
+    }
+    .cms-header { 
+      font: 600 11px/1.2 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      letter-spacing: .06em; 
+      color: #cbd5e1;
+      opacity: .8;
+      margin-bottom: 6px;
+    }
+    .cms-lines { 
+      font: 700 18px/1.35 ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Code", Consolas, "Liberation Mono", monospace;
+      letter-spacing: .08em; 
+      text-transform: uppercase; 
+      display: grid; 
+      gap: 2px; 
+      color: var(--led);
+      text-shadow: 0 0 2px var(--led), 0 0 4px var(--led), 0 0 10px var(--led-glow);
+    }
+    .cms-line { 
+      padding: 2px 4px; 
+      background:
+        radial-gradient(circle at 2px 2px, rgba(255,255,255,.06) 0 1px, transparent 2px) repeat;
+      background-size: 8px 8px; /* faint hole grid */
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+    .cms-meta { color:#94a3b8; font: 500 11px/1.2 ui-sans-serif, system-ui; margin-top:6px; }
   </style>
 </head>
 <body>
@@ -121,6 +162,39 @@
     map.on('error', e => console.error('Map error:', e && e.error || e));
 
     function fetchJSON(url, opts={}){ return fetch(url, opts).then(r => r.ok ? r.json() : null).catch(() => null); }
+
+    // =====================
+    // CMS TEXT HELPERS
+    // =====================
+    function htmlEscape(s){
+      return String(s).replace(/[&<>\"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
+    }
+    function extractPlainText(raw){
+      if(raw==null) return '';
+      // 1) Handle literal \n characters first
+      let s = String(raw).replace(/\\n/g, '\n');
+      // 2) If it contains tags, strip to text content
+      if(/[<>]/.test(s)){
+        const div=document.createElement('div');
+        div.innerHTML=s;
+        s = div.textContent || div.innerText || '';
+      }
+      return s;
+    }
+    function normalizeCmsLines(raw){
+      let s = extractPlainText(raw);
+      // Normalize newlines and whitespace
+      s = s.replace(/\r\n?|\u2028|\u2029/g, '\n'); // CR/LF variants
+      s = s.replace(/[\t\f\v]+/g, ' ');
+      // Collapse 3+ spaces to 1, but preserve single spaces inside words
+      s = s.replace(/ {2,}/g, ' ');
+      // Replace some typical artifacts
+      s = s.replace(/\s*[|·•]+\s*/g, ' • ');
+      // Trim each line and drop empties
+      const lines = s.split('\n').map(l => l.trim()).filter(l => l.length);
+      // All-caps for sign look
+      return lines.map(l => l.toUpperCase());
+    }
 
     map.on('load', () => {
       map.fitBounds(VIEW_BOUNDS, { padding: 40, duration: 0 });
@@ -319,7 +393,50 @@
       const CLICK_LAYERS = ['cctv-lyr','cms-lyr','chp-lyr','lcs-lyr','nws-alerts-fill','fog-lyr','metar-vis-lyr','usgs-lyr','bus-stops-lyr','yarts-stops-lyr','bus-rt-lyr'];
 
       function titleForFeature(f){ const id=f.layer?.id||''; const p=f.properties||{}; if(id==='bus-rt-lyr') return `The Bus — ${p.label||p.id||'Vehicle'}`; if(id==='bus-stops-lyr') return `The Bus — Stop ${p.stop_name||p.stop_id}`; if(id==='yarts-stops-lyr') return `YARTS — Stop ${p.stop_name||p.stop_id}`; if(id==='cctv-lyr') return `CCTV — ${p.locationName||'Camera'}`; if(id==='cms-lyr') return `CMS — ${p.name||p.Title||'Sign'}`; if(id==='chp-lyr') return `CHP — ${p.name||p.Title||'Incident'}`; if(id==='lcs-lyr') return `LCS — ${p.name||p.Title||'Closure'}`; if(id==='nws-alerts-fill'||id==='fog-lyr') return `NWS — ${p.event||'Alert'}`; return 'Feature'; }
-      function htmlForFeature(f){ const id=f.layer?.id||''; const p=f.properties||{}; if(id==='bus-rt-lyr'){ return `<div><strong>The Bus — ${p.label||p.id||'Vehicle'}</strong><br>Route: ${p.route||'—'}<br>Trip: ${p.trip||'—'}<br>Bearing: ${p.bearing??'—'}<br>Speed: ${p.speed? (p.speed*2.237).toFixed(0)+' mph':'—'}<br><small>${p.time? new Date(p.time).toLocaleString(): ''}</small></div>`; } if(/-stops-lyr$/.test(id)){ return `<div><strong>${p.stop_name||'Stop'}</strong><br>ID: ${p.stop_id||''}</div>`; } if(id==='cctv-lyr'){ const url=p.currentImageURL||''; const where = [p.county, p.route].filter(Boolean).join(' · '); return `<div><strong>${p.locationName||'Camera'}</strong>${where? `<div>${where}</div>`:''}${url? `<div style='margin-top:6px'><img src='${url}' style='max-width:320px;max-height:240px;border-radius:8px'></div>`:''}</div>`; } if(id==='cms-lyr'||id==='chp-lyr'||id==='lcs-lyr'){ const title=p.name||p.Title||'Item'; const desc=p.description||p.Description||'<em>No details</em>'; return `<div><strong>${title}</strong><div style='max-width:320px'>${desc}</div>`; } if(id==='nws-alerts-fill'||id==='fog-lyr'){ return `<div><strong>${p.event||'NWS Alert'}</strong><div>${p.headline||''}</div><div><small>${p.effective||''} → ${p.expires||''}</small></div></div>`; } if(id==='usgs-lyr'){ const u=p.url? `<a href='${p.url}' target='_blank' rel='noopener'>Open USGS site</a>`:''; return `<div><strong>${p.name||'USGS Gage'}</strong><br>Site: ${p.site||''}<br>Stage: ${p.stage_ft!=null? Number(p.stage_ft).toFixed(2)+' ft':'—'}<br>Flow: ${p.flow_cfs!=null? Math.round(p.flow_cfs)+' cfs':'—'}<br><small>${p.time? new Date(p.time).toLocaleString(): ''}</small><div style='margin-top:6px'>${u}</div></div>`; } return '<em>Feature</em>'; }
+
+      function cmsPopupHTML(props){
+        const title = props.name || props.Title || 'Sign';
+        const raw = props.description || props.Description || '';
+        const lines = normalizeCmsLines(raw);
+        const body = lines.map(l => `<div class="cms-line">${htmlEscape(l)}</div>`).join('');
+        const meta = [props.direction || props.Direction, props.road || props.Road, props.route || props.Route].filter(Boolean).join(' · ');
+        return `
+          <div class="cms-sign">
+            <div class="cms-header">${htmlEscape(title)}</div>
+            <div class="cms-lines">${body || '<div class="cms-line">NO MESSAGE</div>'}</div>
+            ${meta ? `<div class="cms-meta">${htmlEscape(meta)}</div>`: ''}
+          </div>`;
+      }
+
+      function htmlForFeature(f){
+        const id=f.layer?.id||''; const p=f.properties||{};
+        if(id==='bus-rt-lyr'){
+          return `<div><strong>The Bus — ${p.label||p.id||'Vehicle'}</strong><br>Route: ${p.route||'—'}<br>Trip: ${p.trip||'—'}<br>Bearing: ${p.bearing??'—'}<br>Speed: ${p.speed? (p.speed*2.237).toFixed(0)+' mph':'—'}<br><small>${p.time? new Date(p.time).toLocaleString(): ''}</small></div>`;
+        }
+        if(/-stops-lyr$/.test(id)){
+          return `<div><strong>${p.stop_name||'Stop'}</strong><br>ID: ${p.stop_id||''}</div>`;
+        }
+        if(id==='cctv-lyr'){
+          const url=p.currentImageURL||''; const where = [p.county, p.route].filter(Boolean).join(' · ');
+          return `<div><strong>${p.locationName||'Camera'}</strong>${where? `<div>${where}</div>`:''}${url? `<div style='margin-top:6px'><img src='${url}' style='max-width:320px;max-height:240px;border-radius:8px'></div>`:''}</div>`;
+        }
+        if(id==='cms-lyr'){
+          return cmsPopupHTML(p);
+        }
+        if(id==='chp-lyr'||id==='lcs-lyr'){
+          const title=p.name||p.Title||'Item';
+          const desc=p.description||p.Description||'<em>No details</em>';
+          return `<div><strong>${title}</strong><div style='max-width:320px'>${desc}</div>`;
+        }
+        if(id==='nws-alerts-fill'||id==='fog-lyr'){
+          return `<div><strong>${p.event||'NWS Alert'}</strong><div>${p.headline||''}</div><div><small>${p.effective||''} → ${p.expires||''}</small></div></div>`;
+        }
+        if(id==='usgs-lyr'){
+          const u=p.url? `<a href='${p.url}' target='_blank' rel='noopener'>Open USGS site</a>`:'';
+          return `<div><strong>${p.name||'USGS Gage'}</strong><br>Site: ${p.site||''}<br>Stage: ${p.stage_ft!=null? Number(p.stage_ft).toFixed(2)+' ft':'—'}<br>Flow: ${p.flow_cfs!=null? Math.round(p.flow_cfs)+' cfs':'—'}<br><small>${p.time? new Date(p.time).toLocaleString(): ''}</small><div style='margin-top:6px'>${u}</div></div>`;
+        }
+        return '<em>Feature</em>';
+      }
 
       function showPopup(f, lngLat){ new maplibregl.Popup({maxWidth:'360px'}).setLngLat(lngLat).setHTML(htmlForFeature(f)).addTo(map); }
       map.on('click', (e)=>{


### PR DESCRIPTION
Added a CMS “message board” treatment and a text normalizer—no more \n, weird HTML, or mushy spacing. The popup for CMS points now renders in an amber LED style (monospace, glow, subtle hole grid) and auto-splits into clean uppercase lines.